### PR TITLE
Allows bools to be written and read in multiple yes/no alternatives

### DIFF
--- a/Beat Saber Utils/Utilities/Config.cs
+++ b/Beat Saber Utils/Utilities/Config.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
-
+using System.Linq;
+using System.Globalization;
+using System.Collections.Generic;
 
 namespace BS_Utils.Utilities
 {
@@ -10,11 +10,25 @@ namespace BS_Utils.Utilities
     {
         private IniFile _instance;
 
+        #region Bool Alternatives
+        
+        public enum BoolSavingMode
+        {
+            TrueFalse,
+            OneZero,
+            YesNo,
+            EnabledDisabled,
+            OnOff,
+        };
+
+        private List<string> yesAlts = new List<string>() { "True", "1", "Yes", "Enabled", "On" };
+        private List<string> noAlts = new List<string>() { "False", "0", "No", "Disabled", "Off"};
+        #endregion
+
         public Config(string name)
         {
             _instance = new IniFile(Path.Combine(Environment.CurrentDirectory, $"UserData/{name}.ini"));
         }
-
 
         /// <summary>
         /// Gets a string from the ini.
@@ -84,19 +98,28 @@ namespace BS_Utils.Utilities
         /// <returns></returns>
         public bool GetBool(string section, string name, bool defaultValue = false, bool autoSave = false)
         {
-            string sVal = GetString(section, name, null);
-            if (sVal == "1" || sVal == "0")
-            {
-                return sVal == "1";
-            }
-            else if (autoSave)
-            {
-                SetBool(section, name, defaultValue);
-            }
-
-            return defaultValue;
+            return GetBool(section, name, BoolSavingMode.TrueFalse, defaultValue, autoSave);
         }
 
+        /// <summary>
+        /// Gets a bool from the ini.
+        /// </summary>
+        /// <param name="section">Section of the key.</param>
+        /// <param name="name">Name of the key.</param>
+        /// <param name="mode">Yes/No alternative we should look for.</param>
+        /// <param name="defaultValue">Value that should be used when no value is found.</param>
+        /// <param name="autoSave">Whether or not the default value should be written if no value is found.</param>
+        /// <returns></returns>
+        public bool GetBool(string section, string name, BoolSavingMode mode, bool defaultValue = false, bool autoSave = false)
+        {
+            string sVal = GetString(section, name, null);
+            int yesIndex = yesAlts.IndexOf(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(sVal));
+            int noIndex = noAlts.IndexOf(CultureInfo.CurrentCulture.TextInfo.ToTitleCase(sVal));
+            if (yesIndex != -1 && yesIndex == (int)mode) return true;
+            else if (noIndex != -1 && noIndex == (int)mode) return false;
+            else if (autoSave) SetBool(section, name, defaultValue);
+            return defaultValue;
+        }
 
         /// <summary>
         /// Checks whether or not a key exists in the ini.
@@ -129,7 +152,6 @@ namespace BS_Utils.Utilities
         public void SetInt(string section, string name, int value)
         {
             _instance.IniWriteValue(section, name, value.ToString());
-
         }
 
         /// <summary>
@@ -141,7 +163,6 @@ namespace BS_Utils.Utilities
         public void SetString(string section, string name, string value)
         {
             _instance.IniWriteValue(section, name, value);
-
         }
 
         /// <summary>
@@ -152,11 +173,21 @@ namespace BS_Utils.Utilities
         /// <param name="value">Value that should be written.</param>
         public void SetBool(string section, string name, bool value)
         {
-            _instance.IniWriteValue(section, name, value ? "1" : "0");
-
+            SetBool(section, name, BoolSavingMode.TrueFalse, value);
         }
 
+        /// <summary>
+        /// Sets a bool in the ini.
+        /// </summary>
+        /// <param name="section">Section of the key.</param>
+        /// <param name="name">Name of the key.</param>
+        /// <param name="mode">What common yes/no alternative should we use.</param>
+        /// <param name="value">Value that should be written.</param>
+        public void SetBool(string section, string name, BoolSavingMode mode, bool value)
+        {
+            _instance.IniWriteValue(section, name, value ? yesAlts[(int)mode] : noAlts[(int)mode]);
 
+        }
 
 
     }


### PR DESCRIPTION
Idk more lines of code so you can have stuff like

```ini
[Stuff]
Plugin=Enabled
SuperSecretFeature=On
GnomeOnMiss=Yes
```

and they all return the same value *(as long as you specify which alternative it is using)*.

Also not case sensitive in case you were worrying.

You can easily add to the list by appending to both the enum and the two lists.
