### PR TITLE
Add INIFileParser as project NuGet package

### DIFF
--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -52,8 +52,7 @@
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IllusionPlugin.dll</HintPath>
     </Reference>
     <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\INIFileParser.dll</HintPath>
+      <HintPath>..\packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Beat Saber Utils/packages.config
+++ b/Beat Saber Utils/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ini-parser" version="2.5.2" targetFramework="net46" />
+</packages>


### PR DESCRIPTION
Going by what's in my installation's "Beat Saber_Data\Managed"
directory, INIFileParser is no longer included. Therefore this adds a
NuGet package reference to make this easier to build after cloning.