### PR TITLE
ScoreSubmission disable independent of ResultsViewController

### DIFF
--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -33,8 +33,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony.1.2.0.1, Version=1.2.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.1.2.0.1.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="HMLib">
       <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMLib.dll</HintPath>

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -11,6 +11,8 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         static void Prefix(StandardLevelScenesTransitionSetupDataSO __instance, IDifficultyBeatmap difficultyBeatmap, OverrideEnvironmentSettings overrideEnvironmentSettings, ColorScheme overrideColorScheme,
             GameplayModifiers gameplayModifiers, PlayerSpecificSettings playerSpecificSettings, PracticeSettings practiceSettings, string backButtonText, bool useTestNoteCutSoundEffects)
         {
+            ScoreSubmission._wasDisabled = false;
+            ScoreSubmission.LastDisablers = Array.Empty<string>();
             Plugin.LevelData.GameplayCoreSceneSetupData = new GameplayCoreSceneSetupData(difficultyBeatmap, gameplayModifiers, playerSpecificSettings, practiceSettings, useTestNoteCutSoundEffects);
             Plugin.LevelData.IsSet = true;
             __instance.didFinishEvent -= __instance_didFinishEvent;
@@ -31,6 +33,8 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         static void Prefix(MissionLevelScenesTransitionSetupDataSO __instance, IDifficultyBeatmap difficultyBeatmap,OverrideEnvironmentSettings overrideEnvironmentSettings,
             MissionObjective[] missionObjectives, GameplayModifiers gameplayModifiers, PlayerSpecificSettings playerSpecificSettings)
         {
+            ScoreSubmission._wasDisabled = false;
+            ScoreSubmission.LastDisablers = Array.Empty<string>();
             Plugin.LevelData.GameplayCoreSceneSetupData = new GameplayCoreSceneSetupData(difficultyBeatmap, gameplayModifiers, playerSpecificSettings, PracticeSettings.defaultPracticeSettings, false);
             Plugin.LevelData.IsSet = true;
             __instance.didFinishEvent -= __instance_didFinishEvent;

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/ResultsViewControllerSetDataToUI.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/ResultsViewControllerSetDataToUI.cs
@@ -15,15 +15,15 @@ namespace BS_Utils.Gameplay.HarmonyPatches
             ____failedDifficultyText.overflowMode = TextOverflowModes.Overflow;
             ____failedDifficultyText.richText = true;
 
-            if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
+            if (ScoreSubmission.WasDisabled || ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {
                 ____clearedDifficultyText.text += "  \r\n<color=#ff0000ff><size=60%><b>Score Submission Disabled by: " +
-                    ScoreSubmission.ModString +
+                    ScoreSubmission.LastDisabledModString +
                     " | " +
                     ScoreSubmission.ProlongedModString;
 
                ____failedDifficultyText.text += "  \r\n<color=#ff0000ff><size=60%><b>Score Submission Disabled by: " +
-                    ScoreSubmission.ModString +
+                    ScoreSubmission.LastDisabledModString +
                     " | " +
                     ScoreSubmission.ProlongedModString;
             }

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/SoloFreePlayFlowCoordinatorProcessScore.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/SoloFreePlayFlowCoordinatorProcessScore.cs
@@ -9,9 +9,9 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Prefix(LevelCompletionResults levelCompletionResults, ref bool practice)
         {
-            if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
+            if (ScoreSubmission.WasDisabled || ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {
-                //Utilities.Logger.Log("Score Submission Disabled");
+                //Utilities.Logger.Log($"Score Submission Disabled by {string.Join("|", ScoreSubmission.LastDisablers)}");
                 practice = true;
             }
         }


### PR DESCRIPTION
Creates WasDisabled and LastDisablers properties in ScoreSubmission that hold the values of 'disabled' and 'ModList' for the last level played. The submission disable logic and UI use those values and 'disabled' and 'ModList' get reset on LevelData.didFinishEvent, removing the dependency on ResultsViewController to reset them when a level is cleared.