### PR TITLE
Scoresaber fix

### DIFF
--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -135,12 +135,14 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="BuildTargets.targets" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="BuildTargets.targets" />
   <PropertyGroup>
-    <PostBuildEvent></PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <ProjectExtensions />
 </Project>

--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PathMap>$(SolutionDir)=C:\</PathMap>
+    <BeatSaberDir>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber</BeatSaberDir>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -137,8 +138,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="BuildTargets.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetDir)$(TargetFileName)" "C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins"</PostBuildEvent>
+    <PostBuildEvent></PostBuildEvent>
   </PropertyGroup>
   <ProjectExtensions />
 </Project>

--- a/Beat Saber Utils/BuildTargets.targets
+++ b/Beat Saber Utils/BuildTargets.targets
@@ -3,7 +3,7 @@
      and copying the plugin to to your Beat Saber folder. Only edit this if you know what you are doing. -->
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildTargetsVersion>1.1</BuildTargetsVersion>
+    <BuildTargetsVersion>1.2</BuildTargetsVersion>
     <BuildTargetsModified>false</BuildTargetsModified> <!--Set this to true if you edit this file to prevent automatic updates-->
   </PropertyGroup>
   <!--Build Targets-->

--- a/Beat Saber Utils/BuildTargets.targets
+++ b/Beat Saber Utils/BuildTargets.targets
@@ -1,0 +1,304 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains the build tasks and targets for verifying the manifest, zipping Release builds,
+     and copying the plugin to to your Beat Saber folder. Only edit this if you know what you are doing. -->
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildTargetsVersion>1.1</BuildTargetsVersion>
+    <BuildTargetsModified>false</BuildTargetsModified> <!--Set this to true if you edit this file to prevent automatic updates-->
+  </PropertyGroup>
+  <!--Build Targets-->
+  <Target Name="CheckBeatSaberDir" AfterTargets="Build" Condition="!Exists($(BeatSaberDir))">
+    <Message Text="ERROR:" />
+  </Target>
+  <Target Name="ZipRelease" AfterTargets="Build" Condition="'$(DisableZipRelease)' != 'True' AND '$(Configuration)' == 'Release'">
+    <Message Text="Zipping plugin for release." Importance="high" />
+    <GetCommitHash ProjectDir="$(ProjectDir)">
+      <Output TaskParameter="CommitShortHash" PropertyName="CommitShortHash" />
+    </GetCommitHash>
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFiles="$(IntermediateOutputPath)zip\Plugins\$(AssemblyName).dll" />
+    <GetManifestInfo>
+      <Output TaskParameter="PluginVersion" PropertyName="PluginVersion" />
+      <Output TaskParameter="GameVersion" PropertyName="GameVersion" />
+      <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
+    </GetManifestInfo>
+    <Message Text="PluginVersion: $(PluginVersion), AssemblyVersion: $(AssemblyVersion), GameVersion: $(GameVersion)" Importance="high" />
+    <ZipDir DirectoryName="$(IntermediateOutputPath)zip" ZipFileName="$(OutDir)zip\$(AssemblyName)-$(PluginVersion)-bs$(GameVersion)-$(CommitShortHash).zip" />
+  </Target>
+  <Target Name="CopyToPlugins" AfterTargets="Build" Condition="'$(DisableCopyToPlugins)' != 'True'">
+    <Error Text="Unable to copy assembly to game folder. BeatSaberDir doesn't exist: $(BeatSaberDir)" Condition="!Exists($(BeatSaberDir))"/>
+    <Message Text="Copying $(OutputPath)$(AssemblyName).dll to IPA\Pending\Plugins folder" Importance="high" />
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFiles="$(BeatSaberDir)\IPA\Pending\Plugins\$(AssemblyName).dll" />
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).pdb" DestinationFiles="$(BeatSaberDir)\IPA\Pending\Plugins\$(AssemblyName).pdb" />
+  </Target>
+  <!--Build Tasks-->
+  <UsingTask TaskName="GetManifestInfo" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <GameVersion ParameterType="System.String" Output="true" />
+      <PluginVersion ParameterType="System.String" Output="true" />
+      <AssemblyVersion ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Runtime" />
+      <Reference Include="System.Dynamic.Runtime" />
+      <Reference Include="System.ObjectModel" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+            try
+            {
+                string manifestFile = "manifest.json";
+                string assemblyFile = "Properties\\AssemblyInfo.cs";
+                string manifest_gameVerStart = "\"gameVersion\"";
+                string manifest_versionStart = "\"version\"";
+                string manifest_gameVerLine = null;
+                string manifest_versionLine = null;
+                string startString = "[assembly: AssemblyVersion(\"";
+                string secondStartString = "[assembly: AssemblyFileVersion(\"";
+                string assemblyFileVersion = null;
+                string firstLineStr = null;
+                string endLineStr = null;
+                bool badParse = false;
+                int startLine = 1;
+                int endLine = 0;
+                int startColumn = 0;
+                int endColumn = 0;
+                if (!File.Exists(manifestFile))
+                {
+                    throw new FileNotFoundException("Could not find manifest: " + Path.GetFullPath(manifestFile));
+                }
+                if (!File.Exists(assemblyFile))
+                {
+                    throw new FileNotFoundException("Could not find AssemblyInfo: " + Path.GetFullPath(assemblyFile));
+                }
+                string line;
+                using (StreamReader manifestStream = new StreamReader(manifestFile))
+                {
+                    while ((line = manifestStream.ReadLine()) != null && (manifest_versionLine == null || manifest_gameVerLine == null))
+                    {
+                        line = line.Trim();
+                        if (line.StartsWith(manifest_gameVerStart))
+                        {
+                            manifest_gameVerLine = line;
+                        }
+                        else if (line.StartsWith(manifest_versionStart))
+                        {
+                            manifest_versionLine = line;
+                        }
+                    }
+                }
+                if (!string.IsNullOrEmpty(manifest_versionLine))
+                {
+                    PluginVersion = manifest_versionLine.Substring(manifest_versionStart.Length).Replace(":", "").Replace("\"", "").TrimEnd(',').Trim();
+                }
+                else
+                {
+                    Log.LogError("Build", "BSMOD04", "", manifestFile, 0, 0, 0, 0, "PluginVersion not found in manifest.json");
+                    PluginVersion = "E.R.R";
+                }
+
+                if (!string.IsNullOrEmpty(manifest_gameVerLine))
+                {
+                    GameVersion = manifest_gameVerLine.Substring(manifest_gameVerStart.Length).Replace(":", "").Replace("\"", "").TrimEnd(',').Trim();
+                }
+                else
+                {
+                    Log.LogError("Build", "BSMOD05", "", manifestFile, 0, 0, 0, 0, "GameVersion not found in manifest.json");
+                    GameVersion = "E.R.R";
+                }
+
+                line = null;
+                using (StreamReader assemblyStream = new StreamReader(assemblyFile))
+                {
+                    while ((line = assemblyStream.ReadLine()) != null)
+                    {
+                        if (line.Trim().StartsWith(startString))
+                        {
+                            firstLineStr = line;
+                            break;
+                        }
+                        startLine++;
+                        endLine = startLine + 1;
+                    }
+                    while ((line = assemblyStream.ReadLine()) != null)
+                    {
+                        if (line.Trim().StartsWith(secondStartString))
+                        {
+                            endLineStr = line;
+                            break;
+                        }
+                        endLine++;
+                    }
+                }
+                if (!string.IsNullOrEmpty(firstLineStr))
+                {
+                    startColumn = firstLineStr.IndexOf('"') + 1;
+                    endColumn = firstLineStr.LastIndexOf('"');
+                    if (startColumn > 0 && endColumn > 0)
+                        AssemblyVersion = firstLineStr.Substring(startColumn, endColumn - startColumn);
+                    else
+                        badParse = true;
+                }
+                else
+                    badParse = true;
+                if (badParse)
+                {
+                    Log.LogError("Build", "BSMOD03", "", assemblyFile, 0, 0, 0, 0, "Unable to parse the AssemblyVersion from {0}", assemblyFile);
+                    badParse = false;
+                }
+
+                if (PluginVersion != "E.R.R" && AssemblyVersion != PluginVersion)
+                {
+                    Log.LogError("Build", "BSMOD01", "", assemblyFile, startLine, startColumn + 1, startLine, endColumn + 1, "PluginVersion {0} in manifest.json does not match AssemblyVersion {1} in AssemblyInfo.cs", PluginVersion, AssemblyVersion, assemblyFile);
+                    Log.LogMessage(MessageImportance.High, "PluginVersion {0} does not match AssemblyVersion {1}", PluginVersion, AssemblyVersion);
+                }
+                if (!string.IsNullOrEmpty(endLineStr))
+                {
+                    startColumn = endLineStr.IndexOf('"') + 1;
+                    endColumn = endLineStr.LastIndexOf('"');
+                    if (startColumn > 0 && endColumn > 0)
+                    {
+                        assemblyFileVersion = endLineStr.Substring(startColumn, endColumn - startColumn);
+                        if (AssemblyVersion != assemblyFileVersion)
+                            Log.LogWarning("Build", "BSMOD02", "", assemblyFile, endLine, startColumn + 1, endLine, endColumn + 1, "AssemblyVersion {0} does not match AssemblyFileVersion {1} in AssemblyInfo.cs", AssemblyVersion, assemblyFileVersion);
+
+                    }
+                    else
+                    {
+                        Log.LogWarning("Build", "BSMOD06", "", assemblyFile, 0, 0, 0, 0, "Unable to parse the AssemblyFileVersion from {0}", assemblyFile);
+                    }
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                throw;
+                Log.LogErrorFromException(ex);
+                return false;
+            }
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  <!-- Source: https://stackoverflow.com/a/38127938 -->
+  <UsingTask TaskName="ZipDir" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <DirectoryName ParameterType="System.String" Required="true" />
+      <ZipFileName ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.IO.Compression.FileSystem" />
+      <Reference Include="System.IO" />
+      <Using Namespace="System.IO.Compression" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Threading" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        try
+        {
+          var zipDir = new DirectoryInfo(Path.GetDirectoryName(Path.GetFullPath(ZipFileName)));
+          if (zipDir.Exists)
+            zipDir.Delete(true);
+          zipDir.Create();
+          zipDir.Refresh();
+          int tries = 0;
+          while(!zipDir.Exists || tries < 10) // Prevents breaking when Explorer is in the folder.
+          {
+            tries++;
+            Thread.Sleep(50);
+            zipDir.Create();
+            zipDir.Refresh();
+          }
+		  
+          if(File.Exists(ZipFileName))
+            File.Delete(ZipFileName);
+          Log.LogMessage(MessageImportance.High, "Zipping Directory \"{0}\" to \"{1}\"", DirectoryName, ZipFileName);
+          ZipFile.CreateFromDirectory( DirectoryName, ZipFileName );
+          return true;
+        }
+        catch(Exception ex)
+        {
+          Log.LogErrorFromException(ex);
+          return false;
+        }
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  <UsingTask TaskName="GetCommitHash" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <ProjectDir ParameterType="System.String" Required="true" />
+      <CommitShortHash ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.Diagnostics" />
+      <Using Namespace="System.ComponentModel" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+            CommitShortHash = "local";
+            bool noGitFound = false;
+            try
+            {
+                ProjectDir = Path.GetFullPath(ProjectDir);
+                Process process = new Process();
+                string arg = "rev-parse HEAD";
+                process.StartInfo = new ProcessStartInfo("git", arg);
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.WorkingDirectory = ProjectDir;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.Start();
+                string outText = process.StandardOutput.ReadToEnd();
+                if (outText.Length >= 7)
+                {
+                    CommitShortHash = outText.Substring(0, 7);
+                    return true;
+                }
+            }
+            catch (Win32Exception ex)
+            {
+                noGitFound = true;
+                
+            }
+            catch (Exception ex)
+            {
+                Log.LogErrorFromException(ex);
+                return true;
+            }
+            try
+            {
+                string gitPath = Path.GetFullPath(Path.Combine(ProjectDir, ".git"));
+                string headPath = Path.Combine(gitPath, "HEAD");
+                string headContents = null;
+                if (File.Exists(headPath))
+                    headContents = File.ReadAllText(headPath);
+                else
+                {
+                    gitPath = Path.GetFullPath(Path.Combine(ProjectDir, "..", ".git"));
+                    headPath = Path.Combine(gitPath, "HEAD");
+                    if (File.Exists(headPath))
+                        headContents = File.ReadAllText(headPath);
+                }
+                headPath = null;
+                if (!string.IsNullOrEmpty(headContents) && headContents.StartsWith("ref:"))
+                    headPath = Path.Combine(gitPath, headContents.Replace("ref:", "").Trim());
+                if (File.Exists(headPath))
+                {
+                    headContents = File.ReadAllText(headPath);
+                    if (headContents.Length >= 7)
+                        CommitShortHash = headContents.Substring(0, 7);
+                }
+            }
+            catch { }
+            if (CommitShortHash == "local")
+            {
+                if(noGitFound)
+                    Log.LogMessage(MessageImportance.High, "   'git' command not found, unable to retrieve current commit hash.");
+                else
+                    Log.LogMessage(MessageImportance.High, "   Unable to retrieve current commit hash.");
+            }
+            return true;
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>

--- a/Beat Saber Utils/BuildTargets.targets
+++ b/Beat Saber Utils/BuildTargets.targets
@@ -7,9 +7,6 @@
     <BuildTargetsModified>false</BuildTargetsModified> <!--Set this to true if you edit this file to prevent automatic updates-->
   </PropertyGroup>
   <!--Build Targets-->
-  <Target Name="CheckBeatSaberDir" AfterTargets="Build" Condition="!Exists($(BeatSaberDir))">
-    <Message Text="ERROR:" />
-  </Target>
   <Target Name="ZipRelease" AfterTargets="Build" Condition="'$(DisableZipRelease)' != 'True' AND '$(Configuration)' == 'Release'">
     <Message Text="Zipping plugin for release." Importance="high" />
     <GetCommitHash ProjectDir="$(ProjectDir)">

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -123,6 +123,13 @@ namespace BS_Utils.Gameplay
             disabled = false;
             ModList.Clear();
             Plugin.LevelDidFinishEvent -= LevelData_didFinishEvent;
+            if (RemovedFive != null)
+            {
+                StandardLevelScenesTransitionSetupDataSO setupDataSO = Resources.FindObjectsOfTypeAll<StandardLevelScenesTransitionSetupDataSO>().FirstOrDefault();
+                setupDataSO.didFinishEvent -= RemovedFive;
+                setupDataSO.didFinishEvent += RemovedFive;
+                RemovedFive = null;
+            }
             eventSubscribed = false;
         }
 
@@ -146,9 +153,10 @@ namespace BS_Utils.Gameplay
             {
                 prolongedDisable = false;
             }
-                
+
         }
 
+        private static Action<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults> RemovedFive;
         private static bool DisableEvent(object target, string eventName, string delegateName)
         {
             FieldInfo fieldInfo = target.GetType().GetField(eventName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
@@ -162,6 +170,7 @@ namespace BS_Utils.Gameplay
                 {
                     if (item.Method.Name == delegateName)
                     {
+                        RemovedFive = (Action<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults>)item;
                         target.GetType().GetEvent(eventName).RemoveEventHandler(target, item);
                         eventDisabled = true;
                     }

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -104,7 +104,7 @@ namespace BS_Utils.Gameplay
                 ModList.Add(mod);
         }
 
-        public static void DisableScoreSaberScoreSubmission()
+        internal static void DisableScoreSaberScoreSubmission()
         {
             StandardLevelScenesTransitionSetupDataSO setupDataSO = Resources.FindObjectsOfTypeAll<StandardLevelScenesTransitionSetupDataSO>().FirstOrDefault();
             if (setupDataSO == null)

--- a/Beat Saber Utils/Properties/AssemblyInfo.cs
+++ b/Beat Saber Utils/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.6.0")]
-[assembly: AssemblyFileVersion("1.4.6.0")]
+[assembly: AssemblyVersion("1.4.7")]
+[assembly: AssemblyFileVersion("1.4.7")]

--- a/Beat Saber Utils/manifest.json
+++ b/Beat Saber Utils/manifest.json
@@ -5,7 +5,7 @@
   "gameVersion": "1.8.0",
   "id": "BS Utils",
   "name": "BS_Utils",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "features": [
   ]
 } 


### PR DESCRIPTION
* Stores ScoreSaber's 'Five' delegate as a static field in the ScoreSubmission class, restores it after the level finishes.
* Changes the DisableScoreSaberSubmission method to internal instead of public.
* Replaced the PostBuildEvent with BuildTargets.targets.