### PR TITLE
Fixed GetUserInfo for 1.12.2

### DIFF
--- a/Beat Saber Utils/Gameplay/UserInfo.cs
+++ b/Beat Saber Utils/Gameplay/UserInfo.cs
@@ -43,6 +43,11 @@ namespace BS_Utils.Gameplay
             UpdateUserInfo();
         }
 
+        public static IPlatformUserModel GetPlatformUserModel()
+        {
+            return _platformUserModel ?? SetPlatformUserModel();
+        }
+
         internal static IPlatformUserModel SetPlatformUserModel()
         {
             if (_platformUserModel != null)


### PR DESCRIPTION
Tested working with:
* Steam store, Index
* Steam store, `vrmode oculus`, Index (returns the Steam user info)
* Oculus store, Index, Revive (returns Oculus user info)

Avatars seem to work (tested by getting the Texture2D length/width which seemed valid). UserID is a `string` now instead of a `ulong`.