### PR TITLE
GetUserInfo fix, part 2

### DIFF
--- a/Beat Saber Utils/Gameplay/UserInfo.cs
+++ b/Beat Saber Utils/Gameplay/UserInfo.cs
@@ -85,8 +85,6 @@ namespace BS_Utils.Gameplay
 
         public static async void UpdateUserInfo()
         {
-            SetPlatformUserModel();
-
             try
             {
                 await GetUserAsync();
@@ -111,7 +109,7 @@ namespace BS_Utils.Gameplay
                     await shouldBeReadyTask.Task;
                 lock (getUserLock)
                 {
-                    IPlatformUserModel platformUserModel = _platformUserModel ?? SetPlatformUserModel();
+                    IPlatformUserModel platformUserModel = GetPlatformUserModel();
                     if (platformUserModel == null)
                     {
                         Logger.log.Error($"IPlatformUserModel not found, cannot update user info.");

--- a/Beat Saber Utils/Plugin.cs
+++ b/Beat Saber Utils/Plugin.cs
@@ -62,8 +62,11 @@ namespace BS_Utils
 
         public void OnActiveSceneChanged(Scene prevScene, Scene nextScene)
         {
+            if (nextScene.name == "HealthWarning")
+                Gameplay.GetUserInfo.TriggerReady();
             if (nextScene.name == "MenuCore")
             {
+                Gameplay.GetUserInfo.TriggerReady();
                 if (Gamemode.IsIsolatedLevel) // Only remove is necessary.
                     Logger.Log("Removing Isolated Level");
                 Gamemode.IsIsolatedLevel = false;


### PR DESCRIPTION
If a mod attempts to retrieve the user info (or triggers GetUserInfo's static constructor) too early, it will fail and stay broken. This makes the task wait for either the HealthWarning or MenuCore scene.