### PR TITLE
Level finished events

### DIFF
--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -135,6 +135,7 @@
     <Compile Include="SceneNames.cs" />
     <Compile Include="Utilities\BSEvents.cs" />
     <Compile Include="Utilities\Config.cs" />
+    <Compile Include="Utilities\Events\EventExtensions.cs" />
     <Compile Include="Utilities\IniFile.cs" />
     <Compile Include="Utilities\Logger.cs" />
     <Compile Include="Utilities\ReflectionUtil.cs" />

--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Gameplay\LevelData.cs" />
     <Compile Include="Gameplay\ScoreSubmission.cs" />
     <Compile Include="Gameplay\UserInfo.cs" />
+    <Compile Include="LevelFinishedEventArgs.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -124,7 +124,7 @@
     <Compile Include="Gameplay\LevelData.cs" />
     <Compile Include="Gameplay\ScoreSubmission.cs" />
     <Compile Include="Gameplay\UserInfo.cs" />
-    <Compile Include="LevelFinishedEventArgs.cs" />
+    <Compile Include="Utilities\LevelFinishedEventArgs.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -109,4 +109,23 @@ namespace BS_Utils.Gameplay.HarmonyPatches
             Plugin.TriggerMissionFinishEvent(missionLevelScenesTransitionSetupDataSO, missionCompletionResults);
         }
     }
+
+    [HarmonyPatch(typeof(TutorialScenesTransitionSetupDataSO), "Init")]
+    class BlahBlahSetTutorialEvent
+    {
+        static void Prefix(TutorialScenesTransitionSetupDataSO __instance)
+        {
+            ScoreSubmission._wasDisabled = false;
+            ScoreSubmission.LastDisablers = Array.Empty<string>();
+
+            __instance.didFinishEvent -= __instance_didFinishEvent;
+            __instance.didFinishEvent += __instance_didFinishEvent;
+
+        }
+
+        private static void __instance_didFinishEvent(TutorialScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, TutorialScenesTransitionSetupDataSO.TutorialEndStateType endState)
+        {
+            Plugin.TriggerTutorialFinishEvent(missionLevelScenesTransitionSetupDataSO, endState);
+        }
+    }
 }

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -35,12 +35,13 @@ namespace BS_Utils.Gameplay.HarmonyPatches
             Plugin.LevelData.Mode = Mode.Standard;
             Utilities.Logger.log.Debug("Level Data set");
             __instance.didFinishEvent -= __instance_didFinishEvent;
-            __instance.didFinishEvent += __instance_didFinishEvent;
+            __instance.didFinishEvent += __instance_didFinishEvent; // Not triggered in multiplayer
 
         }
 
         private static void __instance_didFinishEvent(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
         {
+            Utilities.Logger.log.Debug("Triggering LevelFinishEvent.");
             Plugin.TriggerLevelFinishEvent(levelScenesTransitionSetupDataSO, levelCompletionResults);
         }
     }
@@ -78,6 +79,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
 
         private static void __instance_didFinishEvent(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, System.Collections.Generic.Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults)
         {
+            Utilities.Logger.log.Debug("Triggering Multiplayer LevelFinishEvent.");
             Plugin.TriggerMultiplayerLevelDidFinish(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults);
         }
     }

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BS_Utils.Utilities;
 using HarmonyLib;
 using IPA.Logging;
 
@@ -43,6 +44,8 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         {
             Utilities.Logger.log.Debug("Triggering LevelFinishEvent.");
             Plugin.TriggerLevelFinishEvent(levelScenesTransitionSetupDataSO, levelCompletionResults);
+            BSEvents.TriggerLevelFinishEvent(levelScenesTransitionSetupDataSO, levelCompletionResults);
+
         }
     }
 
@@ -81,6 +84,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         {
             Utilities.Logger.log.Debug("Triggering Multiplayer LevelFinishEvent.");
             Plugin.TriggerMultiplayerLevelDidFinish(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults);
+            BSEvents.TriggerMultiplayerLevelDidFinish(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults);
         }
     }
     [HarmonyPatch(typeof(MissionLevelScenesTransitionSetupDataSO), "Init")]
@@ -107,6 +111,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         private static void __instance_didFinishEvent(MissionLevelScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults)
         {
             Plugin.TriggerMissionFinishEvent(missionLevelScenesTransitionSetupDataSO, missionCompletionResults);
+            BSEvents.TriggerMissionFinishEvent(missionLevelScenesTransitionSetupDataSO, missionCompletionResults);
         }
     }
 
@@ -126,6 +131,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         private static void __instance_didFinishEvent(TutorialScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, TutorialScenesTransitionSetupDataSO.TutorialEndStateType endState)
         {
             Plugin.TriggerTutorialFinishEvent(missionLevelScenesTransitionSetupDataSO, endState);
+            BSEvents.TriggerTutorialFinishEvent(missionLevelScenesTransitionSetupDataSO, endState);
         }
     }
 }

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -95,7 +95,7 @@ namespace BS_Utils.Gameplay
 
                 if (!eventSubscribed)
                 {
-                    Plugin.LevelDidFinishEvent += LevelData_didFinishEvent;
+                    Plugin.LevelFinished += LevelData_didFinishEvent;
                     eventSubscribed = true;
                 }
             }
@@ -116,13 +116,13 @@ namespace BS_Utils.Gameplay
             DisableEvent(setupDataSO, "didFinishEvent", "Five");
         }
 
-        private static void LevelData_didFinishEvent(StandardLevelScenesTransitionSetupDataSO arg1, LevelCompletionResults arg2)
+        private static void LevelData_didFinishEvent(object sender, LevelFinishedEventArgs args)
         {
             _wasDisabled = disabled;
             _lastDisablers = ModList.ToArray();
             disabled = false;
             ModList.Clear();
-            Plugin.LevelDidFinishEvent -= LevelData_didFinishEvent;
+            Plugin.LevelFinished -= LevelData_didFinishEvent;
             if (RemovedFive != null)
             {
                 StandardLevelScenesTransitionSetupDataSO setupDataSO = Resources.FindObjectsOfTypeAll<StandardLevelScenesTransitionSetupDataSO>().FirstOrDefault();

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BS_Utils.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Beat Saber Utils/LevelFinishedEventArgs.cs
+++ b/Beat Saber Utils/LevelFinishedEventArgs.cs
@@ -61,6 +61,7 @@ namespace BS_Utils
         }
 
     }
+
     public class CampaignLevelFinishedEventArgs : LevelFinishedEventArgs
     {
         public readonly MissionCompletionResults CompletionResults;
@@ -70,12 +71,22 @@ namespace BS_Utils
             CompletionResults = levelCompletionResults;
         }
     }
+    public class TutorialLevelFinishedEventArgs : LevelFinishedEventArgs
+    {
+        public readonly TutorialScenesTransitionSetupDataSO.TutorialEndStateType EndState;
+        public TutorialLevelFinishedEventArgs(TutorialScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, TutorialScenesTransitionSetupDataSO.TutorialEndStateType endState)
+            : base(LevelType.Tutorial, levelScenesTransitionSetupDataSO)
+        {
+            EndState = endState;
+        }
+    }
 
 
     public enum LevelType
     {
         SoloParty,
         Multiplayer,
-        Campaign
+        Campaign,
+        Tutorial
     }
 }

--- a/Beat Saber Utils/LevelFinishedEventArgs.cs
+++ b/Beat Saber Utils/LevelFinishedEventArgs.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BS_Utils
+{
+    public class LevelFinishedEventArgs : EventArgs
+    {
+        public readonly LevelType LevelType;
+        public readonly ScenesTransitionSetupDataSO ScenesTransitionSetupDataSO;
+        protected LevelFinishedEventArgs(LevelType levelType, ScenesTransitionSetupDataSO scenesTransitionSetupDataSO)
+        {
+            LevelType = levelType;
+            ScenesTransitionSetupDataSO = scenesTransitionSetupDataSO;
+        }
+    }
+
+    public class SoloLevelFinishedEventArgs : LevelFinishedEventArgs
+    {
+        public readonly LevelCompletionResults CompletionResults;
+        public SoloLevelFinishedEventArgs(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
+            : base(LevelType.SoloParty, levelScenesTransitionSetupDataSO)
+        {
+            CompletionResults = levelCompletionResults;
+        }
+    }
+    public class MultiplayerLevelFinishedEventArgs : LevelFinishedEventArgs
+    {
+        public readonly LevelCompletionResults CompletionResults;
+        private readonly Dictionary<string, LevelCompletionResults> playersCompletionResults;
+
+        /// <summary>
+        /// Gets the <see cref="LevelCompletionResults"/> for the specified player ID. 
+        /// Returns null if there is no matching player ID.
+        /// </summary>
+        /// <param name="playerId"></param>
+        /// <returns></returns>
+        public LevelCompletionResults GetPlayerResults(string playerId)
+        {
+            if (playersCompletionResults == null)
+                return null;
+            if(playersCompletionResults.TryGetValue(playerId, out LevelCompletionResults value))
+            {
+                return value;
+            }
+            return null;
+        }
+
+        public IEnumerator<KeyValuePair<string, LevelCompletionResults>> PlayerResults()
+        {
+            return playersCompletionResults.GetEnumerator();
+        }
+
+        public MultiplayerLevelFinishedEventArgs(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults)
+            : base(LevelType.Multiplayer, levelScenesTransitionSetupDataSO)
+        {
+            CompletionResults = levelCompletionResults;
+            playersCompletionResults = otherPlayersLevelCompletionResults;
+        }
+
+    }
+    public class CampaignLevelFinishedEventArgs : LevelFinishedEventArgs
+    {
+        public readonly MissionCompletionResults CompletionResults;
+        public CampaignLevelFinishedEventArgs(MissionLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, MissionCompletionResults levelCompletionResults)
+            : base(LevelType.Campaign, levelScenesTransitionSetupDataSO)
+        {
+            CompletionResults = levelCompletionResults;
+        }
+    }
+
+
+    public enum LevelType
+    {
+        SoloParty,
+        Multiplayer,
+        Campaign
+    }
+}

--- a/Beat Saber Utils/LevelFinishedEventArgs.cs
+++ b/Beat Saber Utils/LevelFinishedEventArgs.cs
@@ -8,6 +8,9 @@ namespace BS_Utils
 {
     public class LevelFinishedEventArgs : EventArgs
     {
+        /// <summary>
+        /// The type of level that finished.
+        /// </summary>
         public readonly LevelType LevelType;
         public readonly ScenesTransitionSetupDataSO ScenesTransitionSetupDataSO;
         protected LevelFinishedEventArgs(LevelType levelType, ScenesTransitionSetupDataSO scenesTransitionSetupDataSO)

--- a/Beat Saber Utils/Plugin.cs
+++ b/Beat Saber Utils/Plugin.cs
@@ -21,8 +21,11 @@ namespace BS_Utils
         internal static bool patched = false;
         internal static Harmony harmony;
         public static LevelData LevelData = new LevelData();
+        [Obsolete("Use LevelFinished event.")]
         public delegate void LevelDidFinish(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults);
+        [Obsolete("Use LevelFinished event.")]
         public static event LevelDidFinish LevelDidFinishEvent;
+        public static event EventHandler<LevelFinishedEventArgs> LevelFinished;
         public delegate void MultiLevelDidFinish(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, System.Collections.Generic.Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults);
         public static event MultiLevelDidFinish MultiLevelDidFinishEvent;
         public delegate void MissionDidFinish(MissionLevelScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults);
@@ -80,15 +83,21 @@ namespace BS_Utils
 
         internal static void TriggerLevelFinishEvent(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
         {
+            Logger.log.Debug("Solo/Party mode level finished.");
+            LevelFinished?.Invoke(levelScenesTransitionSetupDataSO, new SoloLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults));
             LevelDidFinishEvent?.Invoke(levelScenesTransitionSetupDataSO, levelCompletionResults);
         }
 
         internal static void TriggerMultiplayerLevelDidFinish(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, System.Collections.Generic.Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults)
         {
+            Logger.log.Debug("Multiplayer level finished.");
+            LevelFinished?.Invoke(levelScenesTransitionSetupDataSO, new MultiplayerLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults));
             MultiLevelDidFinishEvent?.Invoke(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults);
         }
         internal static void TriggerMissionFinishEvent(MissionLevelScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults)
         {
+            Logger.log.Debug("Campaign level finished.");
+            LevelFinished?.Invoke(missionLevelScenesTransitionSetupDataSO, new CampaignLevelFinishedEventArgs(missionLevelScenesTransitionSetupDataSO, missionCompletionResults));
             MissionDidFinishEvent?.Invoke(missionLevelScenesTransitionSetupDataSO, missionCompletionResults);
         }
 

--- a/Beat Saber Utils/Plugin.cs
+++ b/Beat Saber Utils/Plugin.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using System.Linq;
 using Logger = BS_Utils.Utilities.Logger;
 using IPA.Utilities.Async;
+using BS_Utils.Utilities.Events;
 
 namespace BS_Utils
 {
@@ -21,14 +22,18 @@ namespace BS_Utils
         internal static bool patched = false;
         internal static Harmony harmony;
         public static LevelData LevelData = new LevelData();
-        [Obsolete("Use LevelFinished event.")]
+        [Obsolete("Use Utilities.BSEvents.LevelFinished event.")]
         public delegate void LevelDidFinish(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults);
-        [Obsolete("Use LevelFinished event.")]
+        [Obsolete("Use Utilities.BSEvents.LevelFinished event.")]
         public static event LevelDidFinish LevelDidFinishEvent;
-        public static event EventHandler<LevelFinishedEventArgs> LevelFinished;
+        internal static event EventHandler<LevelFinishedEventArgs> LevelFinished; // Raised before the BSEvents version.
+        [Obsolete("Use Utilities.BSEvents.LevelFinished event.")]
         public delegate void MultiLevelDidFinish(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, System.Collections.Generic.Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults);
+        [Obsolete("Use Utilities.BSEvents.LevelFinished event.")]
         public static event MultiLevelDidFinish MultiLevelDidFinishEvent;
+        [Obsolete("Use Utilities.BSEvents.LevelFinished event.")]
         public delegate void MissionDidFinish(MissionLevelScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults);
+        [Obsolete("Use Utilities.BSEvents.LevelFinished event.")]
         public static event MissionDidFinish MissionDidFinishEvent;
 
         [OnStart]
@@ -84,26 +89,26 @@ namespace BS_Utils
         internal static void TriggerLevelFinishEvent(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
         {
             Logger.log.Debug("Solo/Party mode level finished.");
-            LevelFinished?.Invoke(levelScenesTransitionSetupDataSO, new SoloLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults));
+            LevelFinished?.RaiseEventSafe(levelScenesTransitionSetupDataSO, new SoloLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults), nameof(LevelFinished));
             LevelDidFinishEvent?.Invoke(levelScenesTransitionSetupDataSO, levelCompletionResults);
         }
 
         internal static void TriggerMultiplayerLevelDidFinish(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, System.Collections.Generic.Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults)
         {
             Logger.log.Debug("Multiplayer level finished.");
-            LevelFinished?.Invoke(levelScenesTransitionSetupDataSO, new MultiplayerLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults));
+            LevelFinished?.RaiseEventSafe(levelScenesTransitionSetupDataSO, new MultiplayerLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults), nameof(LevelFinished));
             MultiLevelDidFinishEvent?.Invoke(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults);
         }
         internal static void TriggerMissionFinishEvent(MissionLevelScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults)
         {
             Logger.log.Debug("Campaign level finished.");
-            LevelFinished?.Invoke(missionLevelScenesTransitionSetupDataSO, new CampaignLevelFinishedEventArgs(missionLevelScenesTransitionSetupDataSO, missionCompletionResults));
+            LevelFinished?.RaiseEventSafe(missionLevelScenesTransitionSetupDataSO, new CampaignLevelFinishedEventArgs(missionLevelScenesTransitionSetupDataSO, missionCompletionResults), nameof(LevelFinished));
             MissionDidFinishEvent?.Invoke(missionLevelScenesTransitionSetupDataSO, missionCompletionResults);
         }
         internal static void TriggerTutorialFinishEvent(TutorialScenesTransitionSetupDataSO tutorialLevelScenesTransitionSetupDataSO, TutorialScenesTransitionSetupDataSO.TutorialEndStateType endState)
         {
             Logger.log.Debug("Tutorial level finished.");
-            LevelFinished?.Invoke(tutorialLevelScenesTransitionSetupDataSO, new TutorialLevelFinishedEventArgs(tutorialLevelScenesTransitionSetupDataSO, endState));
+            LevelFinished?.RaiseEventSafe(tutorialLevelScenesTransitionSetupDataSO, new TutorialLevelFinishedEventArgs(tutorialLevelScenesTransitionSetupDataSO, endState), nameof(LevelFinished));
         }
 
         internal static void ApplyHarmonyPatches()

--- a/Beat Saber Utils/Plugin.cs
+++ b/Beat Saber Utils/Plugin.cs
@@ -100,6 +100,11 @@ namespace BS_Utils
             LevelFinished?.Invoke(missionLevelScenesTransitionSetupDataSO, new CampaignLevelFinishedEventArgs(missionLevelScenesTransitionSetupDataSO, missionCompletionResults));
             MissionDidFinishEvent?.Invoke(missionLevelScenesTransitionSetupDataSO, missionCompletionResults);
         }
+        internal static void TriggerTutorialFinishEvent(TutorialScenesTransitionSetupDataSO tutorialLevelScenesTransitionSetupDataSO, TutorialScenesTransitionSetupDataSO.TutorialEndStateType endState)
+        {
+            Logger.log.Debug("Tutorial level finished.");
+            LevelFinished?.Invoke(tutorialLevelScenesTransitionSetupDataSO, new TutorialLevelFinishedEventArgs(tutorialLevelScenesTransitionSetupDataSO, endState));
+        }
 
         internal static void ApplyHarmonyPatches()
         {

--- a/Beat Saber Utils/Utilities/BSEvents.cs
+++ b/Beat Saber Utils/Utilities/BSEvents.cs
@@ -5,6 +5,8 @@ using UnityEngine.SceneManagement;
 using Zenject;
 using System.Collections;
 using System.Collections.Generic;
+using BS_Utils.Utilities.Events;
+
 namespace BS_Utils.Utilities
 {
     public class BSEvents : MonoBehaviour
@@ -37,6 +39,7 @@ namespace BS_Utils.Utilities
         // Game Events
         public static event Action songPaused;
         public static event Action songUnpaused;
+        public static event EventHandler<LevelFinishedEventArgs> LevelFinished;
         public static event Action<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults> levelCleared;
         public static event Action<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults> levelQuit;
         public static event Action<StandardLevelScenesTransitionSetupDataSO, LevelCompletionResults> levelFailed;
@@ -178,7 +181,7 @@ namespace BS_Utils.Utilities
 
         private void MultiControllerStateChanged(MultiplayerController.State newState, ScenesTransitionSetupDataSO transitionSetupData, DiContainer diContainer, MultiplayerController sync = null)
         {
-            if(newState == MultiplayerController.State.Gameplay)
+            if (newState == MultiplayerController.State.Gameplay)
             {
                 sync.stateChangedEvent -= (state) => { MultiControllerStateChanged(state, transitionSetupData, diContainer, sync); };
                 GameSceneSceneWasLoaded(transitionSetupData, diContainer, sync);
@@ -344,5 +347,37 @@ namespace BS_Utils.Utilities
                 }
             }
         }
+
+        #region LevelFinishedInvokers
+        internal static void TriggerLevelFinishEvent(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
+        {
+            Logger.log.Debug("Solo/Party mode level finished.");
+            LevelFinished?.RaiseEventSafe(levelScenesTransitionSetupDataSO,
+                new SoloLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults),
+                nameof(LevelFinished));
+        }
+
+        internal static void TriggerMultiplayerLevelDidFinish(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, System.Collections.Generic.Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults)
+        {
+            Logger.log.Debug("Multiplayer level finished.");
+            LevelFinished?.RaiseEventSafe(levelScenesTransitionSetupDataSO,
+                new MultiplayerLevelFinishedEventArgs(levelScenesTransitionSetupDataSO, levelCompletionResults, otherPlayersLevelCompletionResults),
+                nameof(LevelFinished));
+        }
+        internal static void TriggerMissionFinishEvent(MissionLevelScenesTransitionSetupDataSO missionLevelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults)
+        {
+            Logger.log.Debug("Campaign level finished.");
+            LevelFinished?.RaiseEventSafe(missionLevelScenesTransitionSetupDataSO,
+                new CampaignLevelFinishedEventArgs(missionLevelScenesTransitionSetupDataSO, missionCompletionResults),
+                nameof(LevelFinished));
+        }
+        internal static void TriggerTutorialFinishEvent(TutorialScenesTransitionSetupDataSO tutorialLevelScenesTransitionSetupDataSO, TutorialScenesTransitionSetupDataSO.TutorialEndStateType endState)
+        {
+            Logger.log.Debug("Tutorial level finished.");
+            LevelFinished?.RaiseEventSafe(tutorialLevelScenesTransitionSetupDataSO, 
+                new TutorialLevelFinishedEventArgs(tutorialLevelScenesTransitionSetupDataSO, endState), 
+                nameof(LevelFinished));
+        }
+        #endregion
     }
 }

--- a/Beat Saber Utils/Utilities/Events/EventExtensions.cs
+++ b/Beat Saber Utils/Utilities/Events/EventExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BS_Utils.Utilities.Events
+{
+    public static class EventExtensions
+    {
+        public static void RaiseEventSafe(this EventHandler e, object sender, string eventName)
+        {
+            if (e == null) return;
+            EventHandler[] handlers = e.GetInvocationList().Select(d => (EventHandler)d).ToArray()
+                ?? Array.Empty<EventHandler>();
+            for (int i = 0; i < handlers.Length; i++)
+            {
+                try
+                {
+                    handlers[i].Invoke(sender, EventArgs.Empty);
+                }
+                catch (Exception ex)
+                {
+                    Logger.log?.Error($"Error in '{eventName}' handlers '{handlers[i]?.Method.Name}': {ex.Message}");
+                    Logger.log?.Debug(ex);
+                }
+            }
+        }
+
+        public static void RaiseEventSafe<TArg>(this EventHandler<TArg> e, object sender, TArg args, string eventName)
+        {
+            if (e == null) return;
+            EventHandler<TArg>[] handlers = e.GetInvocationList().Select(d => (EventHandler<TArg>)d).ToArray()
+                ?? Array.Empty<EventHandler<TArg>>();
+            for (int i = 0; i < handlers.Length; i++)
+            {
+                try
+                {
+                    handlers[i].Invoke(sender, args);
+                }
+                catch (Exception ex)
+                {
+                    Logger.log?.Error($"Error in '{eventName}' handlers '{handlers[i]?.Method.Name}': {ex.Message}");
+                    Logger.log?.Debug(ex);
+                }
+            }
+        }
+    }
+}

--- a/Beat Saber Utils/Utilities/Events/EventExtensions.cs
+++ b/Beat Saber Utils/Utilities/Events/EventExtensions.cs
@@ -8,6 +8,13 @@ namespace BS_Utils.Utilities.Events
 {
     public static class EventExtensions
     {
+        /// <summary>
+        /// Raises an event, wrapping each delegate in a try/catch. 
+        /// Exceptions thrown are logged, using <paramref name="eventName"/> to provide the name of the event the exception was thrown from.
+        /// </summary>
+        /// <param name="e"></param>
+        /// <param name="sender"></param>
+        /// <param name="eventName"></param>
         public static void RaiseEventSafe(this EventHandler e, object sender, string eventName)
         {
             if (e == null) return;
@@ -27,6 +34,15 @@ namespace BS_Utils.Utilities.Events
             }
         }
 
+        /// <summary>
+        /// Raises an event, wrapping each delegate in a try/catch. 
+        /// Exceptions thrown are logged, using <paramref name="eventName"/> to provide the name of the event the exception was thrown from.
+        /// </summary>
+        /// <typeparam name="TArg"></typeparam>
+        /// <param name="e"></param>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        /// <param name="eventName"></param>
         public static void RaiseEventSafe<TArg>(this EventHandler<TArg> e, object sender, TArg args, string eventName)
         {
             if (e == null) return;

--- a/Beat Saber Utils/Utilities/LevelFinishedEventArgs.cs
+++ b/Beat Saber Utils/Utilities/LevelFinishedEventArgs.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BS_Utils.Utilities
 {
-    public class LevelFinishedEventArgs : EventArgs
+    public abstract class LevelFinishedEventArgs : EventArgs
     {
         /// <summary>
         /// The type of level that finished.
@@ -20,18 +20,29 @@ namespace BS_Utils.Utilities
         }
     }
 
-    public class SoloLevelFinishedEventArgs : LevelFinishedEventArgs
+    /// <summary>
+    /// <see cref="LevelFinishedEventArgs"/> that contains <see cref="LevelCompletionResults"/>.
+    /// </summary>
+    public abstract class LevelFinishedWithResultsEventArgs : LevelFinishedEventArgs
     {
         public readonly LevelCompletionResults CompletionResults;
-        public SoloLevelFinishedEventArgs(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
-            : base(LevelType.SoloParty, levelScenesTransitionSetupDataSO)
+
+        protected LevelFinishedWithResultsEventArgs(LevelType levelType, ScenesTransitionSetupDataSO scenesTransitionSetupDataSO, LevelCompletionResults completionResults) 
+            : base(levelType, scenesTransitionSetupDataSO)
         {
-            CompletionResults = levelCompletionResults;
         }
     }
-    public class MultiplayerLevelFinishedEventArgs : LevelFinishedEventArgs
+
+    public class SoloLevelFinishedEventArgs : LevelFinishedWithResultsEventArgs
     {
-        public readonly LevelCompletionResults CompletionResults;
+        public SoloLevelFinishedEventArgs(StandardLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults)
+            : base(LevelType.SoloParty, levelScenesTransitionSetupDataSO, levelCompletionResults)
+        {
+        }
+    }
+
+    public class MultiplayerLevelFinishedEventArgs : LevelFinishedWithResultsEventArgs
+    {
         private readonly Dictionary<string, LevelCompletionResults> playersCompletionResults;
 
         /// <summary>
@@ -57,21 +68,20 @@ namespace BS_Utils.Utilities
         }
 
         public MultiplayerLevelFinishedEventArgs(MultiplayerLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, LevelCompletionResults levelCompletionResults, Dictionary<string, LevelCompletionResults> otherPlayersLevelCompletionResults)
-            : base(LevelType.Multiplayer, levelScenesTransitionSetupDataSO)
+            : base(LevelType.Multiplayer, levelScenesTransitionSetupDataSO, levelCompletionResults)
         {
-            CompletionResults = levelCompletionResults;
             playersCompletionResults = otherPlayersLevelCompletionResults;
         }
 
     }
 
-    public class CampaignLevelFinishedEventArgs : LevelFinishedEventArgs
+    public class CampaignLevelFinishedEventArgs : LevelFinishedWithResultsEventArgs
     {
-        public readonly MissionCompletionResults CompletionResults;
-        public CampaignLevelFinishedEventArgs(MissionLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, MissionCompletionResults levelCompletionResults)
-            : base(LevelType.Campaign, levelScenesTransitionSetupDataSO)
+        public readonly MissionCompletionResults MissionCompletionResults;
+        public CampaignLevelFinishedEventArgs(MissionLevelScenesTransitionSetupDataSO levelScenesTransitionSetupDataSO, MissionCompletionResults missionCompletionResults)
+            : base(LevelType.Campaign, levelScenesTransitionSetupDataSO, missionCompletionResults?.levelCompletionResults)
         {
-            CompletionResults = levelCompletionResults;
+            MissionCompletionResults = missionCompletionResults;
         }
     }
     public class TutorialLevelFinishedEventArgs : LevelFinishedEventArgs

--- a/Beat Saber Utils/Utilities/LevelFinishedEventArgs.cs
+++ b/Beat Saber Utils/Utilities/LevelFinishedEventArgs.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BS_Utils
+namespace BS_Utils.Utilities
 {
     public class LevelFinishedEventArgs : EventArgs
     {


### PR DESCRIPTION
* Created a single `LevelFinished` event which is raised for Solo, Part, Multiplayer, Campaign, and Tutorial modes.
  * EventHandler with `LevelFinishedEventArgs`
    * `LevelFinishedEventArgs` has a child class for each level type, which contains the `LevelCompletionResults`, if available, and other relevant data.
    * `LevelFinishedEventArgs` must be cast to a specific type to get `LevelCompletionResults` (not all modes provide `LevelCompletionResults`)
      * Can cast to `LevelFinishedWithResultsEventArgs` for any type that has `LevelCompletionResults` (not tutorial).
  * `Plugin` class has internal event of the same name/type which is raised before the `BSEvents` version (to ensure score submission reset happens first, not sure if that's important)
* Added extensions for `EventHandler`s in the `Utilities.Events` namespace.
  * `RaiseEventSafe` works for any standard `EventHandler`, is safe to use when the event has no subscribers.
  * Wraps each delegate in a try/catch and gives a nice error message for exceptions.