### PR TITLE
Fix NullReferenceException when disabling score submission

### DIFF
--- a/Beat Saber Utils/Gameplay/HarmonyPatches/SoloFreePlayFlowCoordinatorProcessScore.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/SoloFreePlayFlowCoordinatorProcessScore.cs
@@ -19,7 +19,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix(ref LevelCompletionResults __result, LevelCompletionResults.LevelEndStateType levelEndStateType)
         {
-            if ((ScoreSubmission.WasDisabled || ScoreSubmission.disabled || ScoreSubmission.prolongedDisable) && levelEndStateType == LevelCompletionResults.LevelEndStateType.Cleared)
+            if ((ScoreSubmission.WasDisabled || ScoreSubmission.disabled || ScoreSubmission.prolongedDisable) && levelEndStateType == LevelCompletionResults.LevelEndStateType.Cleared && Plugin.scenesTransitionSetupData != null)
             {
                 Plugin.scenesTransitionSetupData.Get<GameplayCoreSceneSetupData>().SetField("practiceSettings", new PracticeSettings());
                 Plugin.scenesTransitionSetupData = null;

--- a/Beat Saber Utils/manifest.json
+++ b/Beat Saber Utils/manifest.json
@@ -5,7 +5,7 @@
   "gameVersion": "1.19.0",
   "id": "BS Utils",
   "name": "BS_Utils",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "dependsOn": {
     "BSIPA": "^4.2.0",
     "Ini Parser":  "^2.5.8"


### PR DESCRIPTION
This exception specifically happens when having Custom Platforms installed, due to it calling `FillLevelCompletionResults` early.
https://github.com/affederaffe/CustomPlatforms/blob/main/Plugin/CustomFloorPlugin/BSEvents.cs#L120-L158

We do a null check to be sure it doesn't happen in the future.