### PR TITLE
Fix level restart from Pause menu not re-enabling ScoreSubmission

### DIFF
--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using BS_Utils.Utilities;
 using HarmonyLib;
+using UnityEngine;
+using Logger = BS_Utils.Utilities.Logger;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
 {
@@ -9,6 +11,8 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix(StandardLevelScenesTransitionSetupDataSO __instance)
         {
+            Debug.Log("StandardLevelScenesTransitionSetupDataSO.Init: Postfix");
+
             ScoreSubmission._wasDisabled = false;
             ScoreSubmission.LastDisablers = Array.Empty<string>();
             Plugin.scenesTransitionSetupData = __instance;
@@ -26,7 +30,6 @@ namespace BS_Utils.Gameplay.HarmonyPatches
             Logger.log.Debug("Triggering LevelFinishEvent.");
             Plugin.TriggerLevelFinishEvent(levelScenesTransitionSetupDataSO, levelCompletionResults);
             BSEvents.TriggerLevelFinishEvent(levelScenesTransitionSetupDataSO, levelCompletionResults);
-
         }
     }
 
@@ -35,6 +38,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix(MultiplayerLevelScenesTransitionSetupDataSO __instance)
         {
+            Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Init: Postfix");
 
             ScoreSubmission._wasDisabled = false;
             ScoreSubmission.LastDisablers = Array.Empty<string>();

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using BS_Utils.Utilities;
 using HarmonyLib;
-using UnityEngine;
+//using UnityEngine;
 using Logger = BS_Utils.Utilities.Logger;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
@@ -11,7 +11,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix(StandardLevelScenesTransitionSetupDataSO __instance)
         {
-            Debug.Log("StandardLevelScenesTransitionSetupDataSO.Init: Postfix");
+            //Debug.Log("StandardLevelScenesTransitionSetupDataSO.Init: Postfix");
 
             ScoreSubmission._wasDisabled = false;
             ScoreSubmission.LastDisablers = Array.Empty<string>();
@@ -38,7 +38,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix(MultiplayerLevelScenesTransitionSetupDataSO __instance)
         {
-            Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Init: Postfix");
+            //Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Init: Postfix");
 
             ScoreSubmission._wasDisabled = false;
             ScoreSubmission.LastDisablers = Array.Empty<string>();

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/LevelRestartControllerRestartLevelPatch.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/LevelRestartControllerRestartLevelPatch.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System;
 using UnityEngine;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
@@ -9,7 +8,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix()
         {
-            Debug.Log("StandardLevelRestartController: Postfix");
+            //Debug.Log("StandardLevelRestartController: Postfix");
             ScoreSubmission.PauseMenuRestart();
         }
     }
@@ -20,7 +19,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix()
         {
-            Debug.Log("MissionLevelRestartController: Postfix");
+            //Debug.Log("MissionLevelRestartController: Postfix");
             ScoreSubmission.PauseMenuRestart();
         }
     }
@@ -31,7 +30,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
     {
         static void Postfix()
         {
-            Debug.Log("TutorialRestartController: Postfix");
+            //Debug.Log("TutorialRestartController: Postfix");
             ScoreSubmission.PauseMenuRestart();
         }
     }

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/LevelRestartControllerRestartLevelPatch.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/LevelRestartControllerRestartLevelPatch.cs
@@ -1,5 +1,5 @@
 ﻿using HarmonyLib;
-using UnityEngine;
+//using UnityEngine;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
 {

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/LevelRestartControllerRestartLevelPatch.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/LevelRestartControllerRestartLevelPatch.cs
@@ -1,0 +1,38 @@
+﻿using HarmonyLib;
+using System;
+using UnityEngine;
+
+namespace BS_Utils.Gameplay.HarmonyPatches
+{
+    [HarmonyPatch(typeof(StandardLevelRestartController), nameof(StandardLevelRestartController.RestartLevel))]
+    internal class StandardLevelRestartControllerPatch
+    {
+        static void Postfix()
+        {
+            Debug.Log("StandardLevelRestartController: Postfix");
+            ScoreSubmission.PauseMenuRestart();
+        }
+    }
+
+
+    [HarmonyPatch(typeof(MissionLevelRestartController), nameof(MissionLevelRestartController.RestartLevel))]
+    internal class MissionLevelRestartControllerPatch
+    {
+        static void Postfix()
+        {
+            Debug.Log("MissionLevelRestartController: Postfix");
+            ScoreSubmission.PauseMenuRestart();
+        }
+    }
+
+
+    [HarmonyPatch(typeof(TutorialRestartController), nameof(TutorialRestartController.RestartLevel))]
+    internal class TutorialRestartControllerPatch
+    {
+        static void Postfix()
+        {
+            Debug.Log("TutorialRestartController: Postfix");
+            ScoreSubmission.PauseMenuRestart();
+        }
+    }
+}

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/ScenesTransitionSetupDataSoFinishPatch.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/ScenesTransitionSetupDataSoFinishPatch.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using System;
 using UnityEngine;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
@@ -24,6 +23,18 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         static void Prefix(MultiplayerLevelScenesTransitionSetupDataSO __instance)
         {
             Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Finish: Prefix");
+
+            if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
+            {
+                ScoreSubmission.DisableScoreSaberScoreSubmission(__instance);
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(MissionLevelScenesTransitionSetupDataSO), nameof(MissionLevelScenesTransitionSetupDataSO.Finish), MethodType.Normal)]
+        static void Prefix(MissionLevelScenesTransitionSetupDataSO __instance)
+        {
+            Debug.Log("MissionLevelScenesTransitionSetupDataSO.Finish: Prefix");
 
             if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/ScenesTransitionSetupDataSoFinishPatch.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/ScenesTransitionSetupDataSoFinishPatch.cs
@@ -1,5 +1,5 @@
 ﻿using HarmonyLib;
-using UnityEngine;
+//using UnityEngine;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
 {
@@ -10,7 +10,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         [HarmonyPatch(typeof(StandardLevelScenesTransitionSetupDataSO), nameof(StandardLevelScenesTransitionSetupDataSO.Finish), MethodType.Normal)]
         static void Prefix(StandardLevelScenesTransitionSetupDataSO __instance)
         {
-            Debug.Log("StandardLevelScenesTransitionSetupDataSO.Finish: Prefix");
+            //Debug.Log("StandardLevelScenesTransitionSetupDataSO.Finish: Prefix");
 
             if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {
@@ -22,7 +22,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         [HarmonyPatch(typeof(MultiplayerLevelScenesTransitionSetupDataSO), nameof(MultiplayerLevelScenesTransitionSetupDataSO.Finish), MethodType.Normal)]
         static void Prefix(MultiplayerLevelScenesTransitionSetupDataSO __instance)
         {
-            Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Finish: Prefix");
+            //Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Finish: Prefix");
 
             if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {
@@ -34,7 +34,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         [HarmonyPatch(typeof(MissionLevelScenesTransitionSetupDataSO), nameof(MissionLevelScenesTransitionSetupDataSO.Finish), MethodType.Normal)]
         static void Prefix(MissionLevelScenesTransitionSetupDataSO __instance)
         {
-            Debug.Log("MissionLevelScenesTransitionSetupDataSO.Finish: Prefix");
+            //Debug.Log("MissionLevelScenesTransitionSetupDataSO.Finish: Prefix");
 
             if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/ScenesTransitionSetupDataSoFinishPatch.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/ScenesTransitionSetupDataSoFinishPatch.cs
@@ -1,4 +1,6 @@
 ﻿using HarmonyLib;
+using System;
+using UnityEngine;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
 {
@@ -9,6 +11,8 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         [HarmonyPatch(typeof(StandardLevelScenesTransitionSetupDataSO), nameof(StandardLevelScenesTransitionSetupDataSO.Finish), MethodType.Normal)]
         static void Prefix(StandardLevelScenesTransitionSetupDataSO __instance)
         {
+            Debug.Log("StandardLevelScenesTransitionSetupDataSO.Finish: Prefix");
+
             if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {
                 ScoreSubmission.DisableScoreSaberScoreSubmission(__instance);
@@ -19,6 +23,8 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         [HarmonyPatch(typeof(MultiplayerLevelScenesTransitionSetupDataSO), nameof(MultiplayerLevelScenesTransitionSetupDataSO.Finish), MethodType.Normal)]
         static void Prefix(MultiplayerLevelScenesTransitionSetupDataSO __instance)
         {
+            Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Finish: Prefix");
+
             if (ScoreSubmission.disabled || ScoreSubmission.prolongedDisable)
             {
                 ScoreSubmission.DisableScoreSaberScoreSubmission(__instance);

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using IPA.Loader;
 using Logger = BS_Utils.Utilities.Logger;
 using LogLevel = IPA.Logging.Logger.Level;
+using UnityEngine;
 
 namespace BS_Utils.Gameplay
 {
@@ -51,6 +52,8 @@ namespace BS_Utils.Gameplay
 
         public static void DisableSubmission(string mod)
         {
+            Debug.Log("DisableSubmission(): " + mod);
+
             if (disabled == false)
             {
                 //Utilities.Logger.log.Warn($"First DisableSubmission by {mod}");
@@ -98,6 +101,8 @@ namespace BS_Utils.Gameplay
 
         internal static void DisableScoreSaberScoreSubmission(LevelScenesTransitionSetupDataSO setupDataSO)
         {
+            Debug.Log("DisableScoreSaberScoreSubmission(): " + setupDataSO.ToString()); ;
+
             if (ScoreSaberSubmissionProperty != null)
             {
                 ScoreSaberSubmissionProperty.SetValue(null, false);
@@ -110,10 +115,13 @@ namespace BS_Utils.Gameplay
 
         private static void LevelData_didFinishEvent(object sender, LevelFinishedEventArgs args)
         {
+            Debug.Log("LevelData_didFinishEvent(): " + args.LevelType.ToString()); ;
+
             _wasDisabled = disabled;
             _lastDisablers = ModList.ToArray();
             disabled = false;
             ModList.Clear();
+
             Plugin.LevelFinished -= LevelData_didFinishEvent;
             Plugin.MultiplayerDidDisconnect -= Plugin_MultiplayerDidDisconnect;
             ScoreSaberSubmissionProperty?.SetValue(null, true);
@@ -202,6 +210,16 @@ namespace BS_Utils.Gameplay
                 }
             }
             return eventDisabled;
+        }
+
+        // Use ONLY for restarts from pause menu
+        internal static void PauseMenuRestart()
+        {
+            _wasDisabled = false;
+            LastDisablers = Array.Empty<string>();
+            ModList.Clear();
+            disabled = false;
+            eventSubscribed = false;
         }
 
         // Used for debugging purposes

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -101,7 +101,7 @@ namespace BS_Utils.Gameplay
 
         internal static void DisableScoreSaberScoreSubmission(LevelScenesTransitionSetupDataSO setupDataSO)
         {
-            Debug.Log("DisableScoreSaberScoreSubmission(): " + setupDataSO.ToString()); ;
+            //Debug.Log("DisableScoreSaberScoreSubmission(): " + setupDataSO.ToString()); ;
 
             if (ScoreSaberSubmissionProperty != null)
             {
@@ -115,7 +115,7 @@ namespace BS_Utils.Gameplay
 
         private static void LevelData_didFinishEvent(object sender, LevelFinishedEventArgs args)
         {
-            Debug.Log("LevelData_didFinishEvent(): " + args.LevelType.ToString()); ;
+            //Debug.Log("LevelData_didFinishEvent(): " + args.LevelType.ToString()); ;
 
             _wasDisabled = disabled;
             _lastDisablers = ModList.ToArray();
@@ -215,11 +215,19 @@ namespace BS_Utils.Gameplay
         // Use ONLY for restarts from pause menu
         internal static void PauseMenuRestart()
         {
+            Logger.Log("RestartLevel from Pause Menu");
+
+            // These are reset in GrabTheLevelData, which doesnt run when restarted from Pause menu (that only runs when restarting from ResultsView)
             _wasDisabled = false;
             LastDisablers = Array.Empty<string>();
-            ModList.Clear();
-            disabled = false;
+
+            // These must be called in ResultsView to actually reset, which doesnt run if restarting from Pause menu
+            ModList.Clear();    // Removes text from ResultsView
+            disabled = false;   // Stops DisableScoreSubmission() from being called. This was otherwise reset to false in LevelData_didFinishEvent and ResultsViewControllerSetDataToUI
+
             eventSubscribed = false;
+            Plugin.LevelFinished -= LevelData_didFinishEvent;
+            Plugin.MultiplayerDidDisconnect -= Plugin_MultiplayerDidDisconnect;
         }
 
         // Used for debugging purposes

--- a/Beat Saber Utils/Gameplay/ScoreSubmission.cs
+++ b/Beat Saber Utils/Gameplay/ScoreSubmission.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using IPA.Loader;
 using Logger = BS_Utils.Utilities.Logger;
 using LogLevel = IPA.Logging.Logger.Level;
-using UnityEngine;
+//using UnityEngine;
 
 namespace BS_Utils.Gameplay
 {
@@ -52,7 +52,7 @@ namespace BS_Utils.Gameplay
 
         public static void DisableSubmission(string mod)
         {
-            Debug.Log("DisableSubmission(): " + mod);
+            //Debug.Log("DisableSubmission(): " + mod);
 
             if (disabled == false)
             {
@@ -228,6 +228,9 @@ namespace BS_Utils.Gameplay
             eventSubscribed = false;
             Plugin.LevelFinished -= LevelData_didFinishEvent;
             Plugin.MultiplayerDidDisconnect -= Plugin_MultiplayerDidDisconnect;
+
+            RemovedSoloFive = null;
+            RemovedMultiFive = null;
         }
 
         // Used for debugging purposes

--- a/Beat Saber Utils/Utilities/BSEvents.cs
+++ b/Beat Saber Utils/Utilities/BSEvents.cs
@@ -189,13 +189,7 @@ namespace BS_Utils.Utilities
 
         private void GameSceneSceneWasLoaded(ScenesTransitionSetupDataSO transitionSetupData, DiContainer diContainer, MultiplayerController sync = null)
         {
-            Debug.Log("GameSceneSceneWasLoaded()");
-
-            /*if (ScoreSubmission._wasDisabled)
-            {
-                ScoreSubmission._wasDisabled = false;
-                ScoreSubmission.LastDisablers = Array.Empty<string>();
-            }*/
+            //Debug.Log("GameSceneSceneWasLoaded()");
 
             var pauseManager = diContainer.TryResolve<PauseController>();
             if (pauseManager != null)

--- a/Beat Saber Utils/Utilities/BSEvents.cs
+++ b/Beat Saber Utils/Utilities/BSEvents.cs
@@ -189,6 +189,14 @@ namespace BS_Utils.Utilities
 
         private void GameSceneSceneWasLoaded(ScenesTransitionSetupDataSO transitionSetupData, DiContainer diContainer, MultiplayerController sync = null)
         {
+            Debug.Log("GameSceneSceneWasLoaded()");
+
+            /*if (ScoreSubmission._wasDisabled)
+            {
+                ScoreSubmission._wasDisabled = false;
+                ScoreSubmission.LastDisablers = Array.Empty<string>();
+            }*/
+
             var pauseManager = diContainer.TryResolve<PauseController>();
             if (pauseManager != null)
             {

--- a/Beat Saber Utils/manifest.json
+++ b/Beat Saber Utils/manifest.json
@@ -5,9 +5,9 @@
   "gameVersion": "1.30.0",
   "id": "BS Utils",
   "name": "BS_Utils",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "dependsOn": {
-    "BSIPA": "^4.2.0",
+    "BSIPA": "^4.3.0",
     "Ini Parser":  "^2.5.9"
   }
 } 

--- a/Beat Saber Utils/manifest.json
+++ b/Beat Saber Utils/manifest.json
@@ -7,7 +7,7 @@
   "name": "BS_Utils",
   "version": "1.12.3",
   "dependsOn": {
-    "BSIPA": "^4.3.0",
+    "BSIPA": "^4.2.0",
     "Ini Parser":  "^2.5.9"
   }
 } 


### PR DESCRIPTION
ScoreSubmission was remaining disabled when the level is restarted from the Pause menu, causing players to lose scores. This was because the LevelScenesTransitionSetupDataSO.Init functions do not run when the level is restarted from the Pause menu (they only run when the level is restarted from the ResultsView button) and the other half of the stuff needed to reset ScoreSubmission status required ResultsView to run.

Added resetting ScoreSubmission from the LevelRestartControllers.