### PR TITLE
Updates for 1.34.6

### DIFF
--- a/Beat Saber Utils/Beat Saber Utils.csproj
+++ b/Beat Saber Utils/Beat Saber Utils.csproj
@@ -55,6 +55,15 @@
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNet.dll</HintPath>
             <Private>False</Private>
         </Reference>
+        <Reference Include="BGNetCore">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="DataModels">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+            <Private>False</Private>
+            <Publicize>True</Publicize>
+        </Reference>
         <Reference Include="GamePlayCore">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GamePlayCore.dll</HintPath>
             <Private>False</Private>

--- a/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
+++ b/Beat Saber Utils/Gameplay/HarmonyPatches/BlahBlahGrabTheLevelData.cs
@@ -6,13 +6,11 @@ using Logger = BS_Utils.Utilities.Logger;
 
 namespace BS_Utils.Gameplay.HarmonyPatches
 {
-    [HarmonyPatch(typeof(StandardLevelScenesTransitionSetupDataSO), nameof(StandardLevelScenesTransitionSetupDataSO.Init))]
+    [HarmonyPatch(typeof(StandardLevelScenesTransitionSetupDataSO), nameof(StandardLevelScenesTransitionSetupDataSO.InitAndSetupScenes))]
     class BlahBlahGrabTheLevelData
     {
         static void Postfix(StandardLevelScenesTransitionSetupDataSO __instance)
         {
-            //Debug.Log("StandardLevelScenesTransitionSetupDataSO.Init: Postfix");
-
             ScoreSubmission._wasDisabled = false;
             ScoreSubmission.LastDisablers = Array.Empty<string>();
             Plugin.scenesTransitionSetupData = __instance;
@@ -33,13 +31,11 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         }
     }
 
-    [HarmonyPatch(typeof(MultiplayerLevelScenesTransitionSetupDataSO), nameof(MultiplayerLevelScenesTransitionSetupDataSO.Init))]
+    [HarmonyPatch(typeof(MultiplayerLevelScenesTransitionSetupDataSO), nameof(MultiplayerLevelScenesTransitionSetupDataSO.InitAndSetupScenes))]
     class BlahBlahGrabTheMultiLevelData
     {
         static void Postfix(MultiplayerLevelScenesTransitionSetupDataSO __instance)
         {
-            //Debug.Log("MultiplayerLevelScenesTransitionSetupDataSO.Init: Postfix");
-
             ScoreSubmission._wasDisabled = false;
             ScoreSubmission.LastDisablers = Array.Empty<string>();
             Plugin.scenesTransitionSetupData = __instance;
@@ -70,7 +66,7 @@ namespace BS_Utils.Gameplay.HarmonyPatches
         }
     }
 
-    [HarmonyPatch(typeof(MissionLevelScenesTransitionSetupDataSO), nameof(MissionLevelScenesTransitionSetupDataSO.Init))]
+    [HarmonyPatch(typeof(MissionLevelScenesTransitionSetupDataSO), MethodType.Constructor)]
     class BlahBlahGrabTheMissionLevelData
     {
         static void Postfix(MissionLevelScenesTransitionSetupDataSO __instance)

--- a/Beat Saber Utils/Utilities/BSEvents.cs
+++ b/Beat Saber Utils/Utilities/BSEvents.cs
@@ -30,10 +30,10 @@ namespace BS_Utils.Utilities
         public static event Action gameSceneLoaded;
 
         // Menu Events
-        public static event Action<StandardLevelDetailViewController, IDifficultyBeatmap> difficultySelected;
+        public static event Action<StandardLevelDetailViewController, BeatmapKey> difficultySelected;
         public static event Action<BeatmapCharacteristicSegmentedControlController, BeatmapCharacteristicSO> characteristicSelected;
-        public static event Action<LevelSelectionNavigationController, IBeatmapLevelPack> levelPackSelected;
-        public static event Action<LevelCollectionViewController, IPreviewBeatmapLevel> levelSelected;
+        public static event Action<LevelSelectionNavigationController, BeatmapLevelPack> levelPackSelected;
+        public static event Action<LevelCollectionViewController, BeatmapLevel> levelSelected;
 
         // Game Events
         public static event Action songPaused;
@@ -144,15 +144,16 @@ namespace BS_Utils.Utilities
             gameScenesManager.transitionDidFinishEvent -= OnMenuSceneWasLoadedFresh;
 
             var levelDetailViewController = Resources.FindObjectsOfTypeAll<StandardLevelDetailViewController>().FirstOrDefault();
-            levelDetailViewController.didChangeDifficultyBeatmapEvent += delegate (StandardLevelDetailViewController vc, IDifficultyBeatmap beatmap) { InvokeAll(difficultySelected, vc, beatmap); };
+            levelDetailViewController.didChangeDifficultyBeatmapEvent += delegate (StandardLevelDetailViewController vc) { InvokeAll(difficultySelected, vc, vc.beatmapKey); };
 
             var characteristicSelect = Resources.FindObjectsOfTypeAll<BeatmapCharacteristicSegmentedControlController>().FirstOrDefault();
             characteristicSelect.didSelectBeatmapCharacteristicEvent += delegate (BeatmapCharacteristicSegmentedControlController controller, BeatmapCharacteristicSO characteristic) { InvokeAll(characteristicSelected, controller, characteristic); };
 
             var packSelectViewController = Resources.FindObjectsOfTypeAll<LevelSelectionNavigationController>().FirstOrDefault();
-            packSelectViewController.didSelectLevelPackEvent += delegate (LevelSelectionNavigationController controller, IBeatmapLevelPack pack) { InvokeAll(levelPackSelected, controller, pack); };
+            packSelectViewController.didSelectLevelPackEvent += delegate (LevelSelectionNavigationController controller, BeatmapLevelPack pack) { InvokeAll(levelPackSelected, controller, pack); };
+            
             var levelSelectViewController = Resources.FindObjectsOfTypeAll<LevelCollectionViewController>().FirstOrDefault();
-            levelSelectViewController.didSelectLevelEvent += delegate (LevelCollectionViewController controller, IPreviewBeatmapLevel level) { InvokeAll(levelSelected, controller, level); };
+            levelSelectViewController.didSelectLevelEvent += delegate (LevelCollectionViewController controller, BeatmapLevel level) { InvokeAll(levelSelected, controller, level); };
 
             InvokeAll(earlyMenuSceneLoadedFresh, transitionSetupData);
             InvokeAll(menuSceneLoadedFresh);


### PR DESCRIPTION
- Updates references for 1.34.6
- Prevents ambiguous patches on `ScenesTransitionSetupDataSO`s
- Updates BSEvents with level selection changes (note: this is a compatibility break)

